### PR TITLE
Updating deprecated lines and hardcoding the directory role ID

### DIFF
--- a/permissions.tf
+++ b/permissions.tf
@@ -83,7 +83,7 @@ resource "azurerm_role_assignment" "installer_subscription" {
 resource "azuread_directory_role_assignment" "installer_directory" {
   count = var.installation_type == "cli" ? 1 : 0
 
-  role_id             = data.external.directory_reader_role.result.id
+  role_id             = var.directory_reader_role_id
   principal_object_id = local.installer_object_id
 }
 

--- a/roles.tf
+++ b/roles.tf
@@ -83,16 +83,20 @@ resource "azurerm_role_definition" "aro" {
 #         for azure ad roles
 #   TODO: fix this
 #
-locals {
-  directory_reader_role_command = <<-EOT
-ID=$(az rest --method GET --url https://graph.microsoft.com/v1.0/roleManagement/directory/roleDefinitions | jq -r '.value[] | select(.displayName == "Directory Readers") | .templateId') && echo "{\"id\":\"$ID\"}"
-EOT
-}
 
-data "external" "directory_reader_role" {
-  program = [
-    "sh",
-    "-c",
-    local.directory_reader_role_command
-  ]
-}
+## The role ID for this role definition will always be 88d8e3e3-8f55-4a1e-953a-9b9898b8876b
+## https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json#directory-readers
+## This can be added as a variable and referenced.
+# locals {
+#   directory_reader_role_command = <<-EOT
+# ID=$(az rest --method GET --url https://graph.microsoft.com/v1.0/roleManagement/directory/roleDefinitions | jq -r '.value[] | select(.displayName == "Directory Readers") | .templateId') && echo "{\"id\":\"$ID\"}"
+# EOT
+# }
+
+# data "external" "directory_reader_role" {
+#   program = [
+#     "sh",
+#     "-c",
+#     local.directory_reader_role_command
+#   ]
+# }

--- a/service_principals.tf
+++ b/service_principals.tf
@@ -24,13 +24,13 @@ resource "azuread_application_password" "cluster" {
   count = var.cluster_service_principal.create ? 1 : 0
 
   display_name          = local.cluster_service_principal_name
-  application_object_id = azuread_application.cluster[0].object_id
+  application_id = azuread_application.cluster[0].id
 }
 
 resource "azuread_service_principal" "cluster" {
   count = var.cluster_service_principal.create ? 1 : 0
 
-  application_id = azuread_application.cluster[0].application_id
+  client_id = azuread_application.cluster[0].client_id
   owners         = [data.azuread_client_config.current.object_id]
 }
 
@@ -64,13 +64,13 @@ resource "azuread_application_password" "installer" {
   count = local.installer_user_set ? 0 : ((var.installer_service_principal.create) ? 1 : 0)
 
   display_name          = local.installer_service_principal_name
-  application_object_id = azuread_application.installer[0].object_id
+  application_id = azuread_application.installer[0].id
 }
 
 resource "azuread_service_principal" "installer" {
   count = local.installer_user_set ? 0 : ((var.installer_service_principal.create) ? 1 : 0)
 
-  application_id = azuread_application.installer[0].application_id
+  client_id = azuread_application.installer[0].client_id
   owners         = [data.azuread_client_config.current.object_id]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -130,3 +130,9 @@ variable "tenant_id" {
   default     = null
   description = "Explicitly use a specific Azure tenant id (defaults to the current system configuration)."
 }
+
+variable "directory_reader_role_id" {
+  type = string
+  default = "88d8e3e3-8f55-4a1e-953a-9b9898b8876b"
+  description = "Directory Readers role ID"  
+}


### PR DESCRIPTION
This PR addresses 2 things:

- Update the deprecated lines
-  Replacing the dynamic query for role ID. Role ID for 'Directory Role' is published by Azure. To speed up execution and limit dependency on local exec, we can simply add the actual ID of this role. [Role Link](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json)

