### PR TITLE
feat: add disk encryption set permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ This section defines the objects which need individual permissions.
 | ---- | ---- | ---- |
 | Subscription | `--subscription` | The highest level a permission will be applied.  Inherits down to all objects within that subscription.  This is not a mandatory flag and the subscription may be set based on how a user has logged in with `az login`. |
 | ARO Resource Group | `--resource-group` | Resource group in the above subscription where the actual ARO object is created. |
-| Cluster Resource Group | `--cluster-resource-group` | Resource group in the above subscription where the underlying ARO object (e.g. VMs, load balancers) are created.  This is created automatically as part of provisioning. |
+| Cluster Resource Group | `--cluster-resource-group` | Resource group in the above subscription where the underlying ARO objects (e.g. VMs, load balancers) are created.  This is created automatically as part of provisioning. |
 | Network Resource Group | `--vnet-resource-group` | Resource group in the above subscription where network resources (e.g. VNET, NSG) exist.  Some organizations will use the Cluster Resource Group for this purpose as well and do not need a dedicated Network Resource Group. |
 | VNET | `--vnet`| VNET where the ARO cluster will be provisioned. |
 | Network Security Group | N/A | Only required for BYO-NSG scenarios.  Network security group, applied to the subnets.  This is is pre-applied by the user to the subnets prior to installation. |
+| Disk Encryption Set | `--disk-encryption-set` | The disk encryption set used to encrypt master and worker node disks. |
 
 
 ## Permissions
@@ -52,14 +53,16 @@ This section identifies what permissions are needed by each individual identity.
 | 1 | [Cluster Service Principal](#identities) | [VNET](#objects) | [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor) or [Minimal Network Permissions](#minimal-network-permissions) | |
 | 2 | [Cluster Service Principal](#identities) | [Network Security Group](#objects) | [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor) or [Minimal Network Permissions](#minimal-network-permissions) | Only needed if BYO-NSG is pre-attached to the subnet. |
 | 3 | [Cluster Service Principal](#identities) | [ARO Resource Group](#objects) | [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor) | |
-| 4 | [Installer](#identities) | [ARO Resource Group](#objects) | [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor) or [Minimal ARO Permissions](#minimal-aro-permissions) | |
-| 5 | [Installer](#identities) | [Network Resource Group](#objects)| [Reader](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader) | Only required if `az aro create` is used to install. |
-| 6 | [Installer](#identities) | [Subscription](#objects) | [User Access Administrator](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#user-access-administrator) | Only required if `az aro create` is used to install. |
-| 7 | [Installer](#identities) | Azure AD | [Directory Readers](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference#directory-readers) | Only required if `az aro create` is used to install. |
-| 8 | [Installer](#identities) | [VNET](#objects) | [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor) or [Minimal Network Permissions](#minimal-network-permissions) | Only required if `az aro create` is used to install. |
-| 9 | [Resource Provider Service Principal](#identities) | [VNET](#objects) | [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor) or [Minimal Network Permissions](#minimal-network-permissions) | |
-| 10 | [Resource Provider Service Principal](#identities) | [Network Security Group](#objects) | [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor) or [Minimal Network Permissions](#minimal-network-permissions) | |
-| 11 | [Resource Provider Service Principal](#identities) | [Cluster Resource Group](#objects) | [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner) | This permission does not need to pre-exist.  It is applied when the Resource Provider Service Principal creates the resource group as part of installation.  This is for documentation purposes only. |
+| 4 | [Cluster Service Principal](#identities) | [Disk Encryption Set](#objects) | [Other](#other-permissions) | |
+| 5 | [Installer](#identities) | [ARO Resource Group](#objects) | [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor) or [Minimal ARO Permissions](#minimal-aro-permissions) | |
+| 6 | [Installer](#identities) | [Network Resource Group](#objects)| [Reader](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader) | Only required if `az aro create` is used to install. |
+| 7 | [Installer](#identities) | [Subscription](#objects) | [User Access Administrator](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#user-access-administrator) | Only required if `az aro create` is used to install. |
+| 8 | [Installer](#identities) | Azure AD | [Directory Readers](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference#directory-readers) | Only required if `az aro create` is used to install. |
+| 9 | [Installer](#identities) | [VNET](#objects) | [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor) or [Minimal Network Permissions](#minimal-network-permissions) | Only required if `az aro create` is used to install. |
+| 10 | [Resource Provider Service Principal](#identities) | [VNET](#objects) | [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor) or [Minimal Network Permissions](#minimal-network-permissions) | |
+| 11 | [Resource Provider Service Principal](#identities) | [Network Security Group](#objects) | [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor) or [Minimal Network Permissions](#minimal-network-permissions) | |
+| 12 | [Resource Provider Service Principal](#identities) | [Disk Encryption Set](#objects) | [Other](#other-permissions) | |
+| 13 | [Resource Provider Service Principal](#identities) | [Cluster Resource Group](#objects) | [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner) | This permission does not need to pre-exist.  It is applied when the Resource Provider Service Principal creates the resource group as part of installation.  This is for documentation purposes only. |
 
 
 ### Minimal Network Permissions
@@ -104,6 +107,13 @@ In addition to minimizing network permissions, the installer role may need minim
 * Microsoft.RedHatOpenShift/openShiftClusters/delete
 * Microsoft.RedHatOpenShift/openShiftClusters/listCredentials/action
 * Microsoft.RedHatOpenShift/openShiftClusters/listAdminCredentials/action
+
+
+### Other Permissions
+
+In addition to the above, the following other permissions may be needed by specific identities:
+
+* [Microsoft.Compute/diskEncryptionSets/read](https://github.com/Azure/ARO-RP/blob/v20240503.00/pkg/validate/dynamic/diskencryptionset.go#L78)
 
 
 ## Prereqs

--- a/examples/api/main.tf
+++ b/examples/api/main.tf
@@ -10,10 +10,10 @@ module "example" {
   installation_type = "api"
 
   # cluster parameters
-  cluster_name           = "dscott-api"
-  vnet                   = "dscott-api-aro-vnet-eastus"
-  vnet_resource_group    = "dscott-api-vnet-rg"
-  network_security_group = "dscott-api-nsg"
+  cluster_name        = "dscott-api"
+  vnet                = "dscott-api-aro-vnet-eastus"
+  vnet_resource_group = "dscott-api-vnet-rg"
+  #network_security_group = "dscott-api-nsg"
   aro_resource_group = {
     name   = "dscott-api-rg"
     create = true

--- a/examples/api/terraform-example/main.tf
+++ b/examples/api/terraform-example/main.tf
@@ -46,7 +46,7 @@ resource "azureopenshift_redhatopenshift_cluster" "cluster" {
   }
 
   worker_profile {
-    subnet_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/dscott-api-vnet-rg/providers/Microsoft.Network/virtualNetworks/dscott-api-aro-vnet-eastus/subnets/dscott-api-aro-worker-subnet-eastus"
+    subnet_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/dscott-api-vnet-rg/providers/Microsoft.Network/virtualNetworks/dscott-api-aro-vnet-eastus/subnets/dscott-api-aro-machine-subnet-eastus"
   }
 
   service_principal {

--- a/output.tf
+++ b/output.tf
@@ -27,8 +27,8 @@ EOT
 locals {
   cluster_service_principal_client_id       = var.cluster_service_principal.create ? azuread_application.cluster[0].client_id : null
   cluster_service_principal_client_secret   = var.cluster_service_principal.create ? azuread_application_password.cluster[0].value : null
-  installer_service_principal_client_id     = var.cluster_service_principal.create ? azuread_application.installer[0].client_id : null
-  installer_service_principal_client_secret = var.cluster_service_principal.create ? azuread_application_password.installer[0].value : null
+  installer_service_principal_client_id     = var.installer_service_principal.create ? azuread_application.installer[0].client_id : null
+  installer_service_principal_client_secret = var.installer_service_principal.create ? azuread_application_password.installer[0].value : null
 }
 
 output "cluster_service_principal_client_id" {

--- a/output.tf
+++ b/output.tf
@@ -2,7 +2,7 @@
 # output created service principals and credentials to a file
 #
 resource "local_sensitive_file" "cluster_service_principal" {
-  count = var.cluster_service_principal.create ? 1 : 0
+  count = var.cluster_service_principal.create && var.output_as_file ? 1 : 0
 
   content         = <<-EOT
 ARO_CLUSTER_SP_CLIENT_ID='${azuread_application.cluster[0].client_id}'
@@ -13,7 +13,7 @@ EOT
 }
 
 resource "local_sensitive_file" "installer_service_principal" {
-  count = local.installer_user_set ? 0 : ((var.installer_service_principal.create) ? 1 : 0)
+  count = local.installer_user_set ? 0 : ((var.installer_service_principal.create && var.output_as_file) ? 1 : 0)
 
   content         = <<-EOT
 ARO_INSTALLER_SP_CLIENT_ID='${azuread_application.installer[0].client_id}'
@@ -22,4 +22,29 @@ ARO_TENANT_ID='${data.azuread_client_config.current.tenant_id}'
 EOT
   filename        = "./${var.cluster_name}_installer-sp-credentials.txt"
   file_permission = "0600"
+}
+
+locals {
+  cluster_service_principal_client_id       = var.cluster_service_principal.create ? azuread_application.cluster[0].client_id : null
+  cluster_service_principal_client_secret   = var.cluster_service_principal.create ? azuread_application_password.cluster[0].value : null
+  installer_service_principal_client_id     = var.cluster_service_principal.create ? azuread_application.installer[0].client_id : null
+  installer_service_principal_client_secret = var.cluster_service_principal.create ? azuread_application_password.installer[0].value : null
+}
+
+output "cluster_service_principal_client_id" {
+  value = local.cluster_service_principal_client_id
+}
+
+output "cluster_service_principal_client_secret" {
+  value     = local.cluster_service_principal_client_secret
+  sensitive = true
+}
+
+output "installer_service_principal_client_id" {
+  value = local.installer_service_principal_client_id
+}
+
+output "installer_service_principal_client_secret" {
+  value     = local.installer_service_principal_client_secret
+  sensitive = true
 }

--- a/permissions.tf
+++ b/permissions.tf
@@ -3,16 +3,10 @@
 #
 data "azurerm_subscription" "current" {}
 
-data "azurerm_virtual_network" "vnet" {
-  name                = var.vnet
-  resource_group_name = data.azurerm_resource_group.network.name
-}
-
-data "azurerm_network_security_group" "vnet" {
-  count = (var.network_security_group == null || var.network_security_group == "") ? 0 : 1
-
-  name                = var.network_security_group
-  resource_group_name = local.network_resource_group
+locals {
+  vnet_id                   = "${local.network_resource_group_id}/providers/Microsoft.Network/virtualNetworks/${var.vnet}"
+  network_security_group_id = (var.network_security_group == null || var.network_security_group == "") ? null : "${local.network_resource_group_id}/providers/Microsoft.Network/networkSecurityGroups/${var.network_security_group}"
+  disk_encryption_set_id    = (var.disk_encryption_set == null || var.disk_encryption_set == "") ? null : "${local.aro_resource_group_id}/providers/Microsoft.Compute/diskEncryptionSets/${var.disk_encryption_set}"
 }
 
 #
@@ -21,7 +15,7 @@ data "azurerm_network_security_group" "vnet" {
 
 # permission 1: assign cluster identity with appropriate vnet permissions
 resource "azurerm_role_assignment" "cluster_vnet" {
-  scope                = data.azurerm_virtual_network.vnet.id
+  scope                = local.vnet_id
   role_definition_id   = local.custom_network_role ? azurerm_role_definition.network[0].role_definition_resource_id : null
   role_definition_name = local.custom_network_role ? null : "Network Contributor"
   principal_id         = local.cluster_service_principal_object_id
@@ -31,7 +25,7 @@ resource "azurerm_role_assignment" "cluster_vnet" {
 resource "azurerm_role_assignment" "cluster_network_security_group" {
   count = (var.network_security_group == null || var.network_security_group == "") ? 0 : 1
 
-  scope                            = data.azurerm_network_security_group.vnet[0].id
+  scope                            = local.network_security_group_id
   role_definition_id               = local.custom_network_role ? azurerm_role_definition.network[0].role_definition_resource_id : null
   role_definition_name             = local.custom_network_role ? null : "Network Contributor"
   principal_id                     = local.cluster_service_principal_object_id
@@ -40,8 +34,18 @@ resource "azurerm_role_assignment" "cluster_network_security_group" {
 
 # permission 3: assign cluster identity with contributor permissions on the aro resource group
 resource "azurerm_role_assignment" "cluster_aro_resource_group" {
-  scope                            = local.aro_resource_group.id
+  scope                            = local.aro_resource_group_id
   role_definition_name             = "Contributor"
+  principal_id                     = local.cluster_service_principal_object_id
+  skip_service_principal_aad_check = var.cluster_service_principal.create
+}
+
+# permission 4: assign cluster identity with appropriate disk encryption set permissions
+resource "azurerm_role_assignment" "cluster_disk_encryption_set" {
+  count = local.custom_des_role ? 1 : 0
+
+  scope                            = local.disk_encryption_set_id
+  role_definition_id               = local.custom_des_role ? azurerm_role_definition.des[0].role_definition_resource_id : null
   principal_id                     = local.cluster_service_principal_object_id
   skip_service_principal_aad_check = var.cluster_service_principal.create
 }
@@ -50,26 +54,26 @@ resource "azurerm_role_assignment" "cluster_aro_resource_group" {
 # installer service principal permissions
 #
 
-# permission 4: assign installer identity with appropriate aro resource group permissions
+# permission 5: assign installer identity with appropriate aro resource group permissions
 resource "azurerm_role_assignment" "installer_aro_resource_group" {
-  scope                            = local.aro_resource_group.id
+  scope                            = local.aro_resource_group_id
   role_definition_id               = local.custom_aro_role ? azurerm_role_definition.aro[0].role_definition_resource_id : null
   role_definition_name             = local.custom_aro_role ? null : "Contributor"
   principal_id                     = local.installer_object_id
   skip_service_principal_aad_check = var.installer_service_principal.create
 }
 
-# permission 5: assign installer identity reader to the network resource group if using a cli installation
+# permission 6: assign installer identity reader to the network resource group if using a cli installation
 resource "azurerm_role_assignment" "installer_network_resource_group" {
   count = var.installation_type == "cli" ? 1 : 0
 
-  scope                            = data.azurerm_resource_group.network.id
+  scope                            = local.network_resource_group_id
   role_definition_name             = "Reader"
   principal_id                     = local.installer_object_id
   skip_service_principal_aad_check = var.installer_service_principal.create
 }
 
-# permission 6: assign installer identity user access admin to the subscription if using a cli installation
+# permission 7: assign installer identity user access admin to the subscription if using a cli installation
 resource "azurerm_role_assignment" "installer_subscription" {
   count = var.installation_type == "cli" ? 1 : 0
 
@@ -79,19 +83,26 @@ resource "azurerm_role_assignment" "installer_subscription" {
   skip_service_principal_aad_check = var.installer_service_principal.create
 }
 
-# permission 7: assign installer identity directory reader in azure ad if using a cli installation
+# permission 8: assign installer identity directory reader in azure ad if using a cli installation
+# NOTE:
+#   - The role ID for this role definition will always be 88d8e3e3-8f55-4a1e-953a-9b9898b8876b
+#   - https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json#directory-readers
+locals {
+  directory_reader_role_id = "88d8e3e3-8f55-4a1e-953a-9b9898b8876b"
+}
+
 resource "azuread_directory_role_assignment" "installer_directory" {
   count = var.installation_type == "cli" ? 1 : 0
 
-  role_id             = var.directory_reader_role_id
+  role_id             = local.directory_reader_role_id
   principal_object_id = local.installer_object_id
 }
 
-# permission 8: assign installer identity with appropriate vnet permissions
+# permission 9: assign installer identity with appropriate vnet permissions
 resource "azurerm_role_assignment" "installer_vnet" {
   count = var.installation_type == "cli" ? 1 : 0
 
-  scope                = data.azurerm_virtual_network.vnet.id
+  scope                = local.vnet_id
   role_definition_id   = local.custom_network_role ? azurerm_role_definition.network[0].role_definition_resource_id : null
   role_definition_name = local.custom_network_role ? null : "Network Contributor"
   principal_id         = local.installer_object_id
@@ -101,20 +112,29 @@ resource "azurerm_role_assignment" "installer_vnet" {
 # resource provider service principal permissions
 #
 
-# permission 9: assign resource provider service principal with appropriate vnet permissions
+# permission 10: assign resource provider service principal with appropriate vnet permissions
 resource "azurerm_role_assignment" "resource_provider_vnet" {
-  scope                = data.azurerm_virtual_network.vnet.id
+  scope                = local.vnet_id
   role_definition_id   = local.custom_network_role ? azurerm_role_definition.network[0].role_definition_resource_id : null
   role_definition_name = local.custom_network_role ? null : "Network Contributor"
   principal_id         = data.azuread_service_principal.aro_resource_provider.object_id
 }
 
-# permission 10: assign resource provider service principal with appropriate network security group permissions
+# permission 11: assign resource provider service principal with appropriate network security group permissions
 resource "azurerm_role_assignment" "resource_provider_network_security_group" {
   count = (var.network_security_group == null || var.network_security_group == "") ? 0 : 1
 
-  scope                = data.azurerm_network_security_group.vnet[0].id
+  scope                = local.network_security_group_id
   role_definition_id   = local.custom_network_role ? azurerm_role_definition.network[0].role_definition_resource_id : null
   role_definition_name = local.custom_network_role ? null : "Network Contributor"
   principal_id         = data.azuread_service_principal.aro_resource_provider.object_id
+}
+
+# permission 12: assign resource provider service principal with appropriate disk encryption set permissions
+resource "azurerm_role_assignment" "resource_provider_disk_encryption_set" {
+  count = local.custom_des_role ? 1 : 0
+
+  scope              = local.disk_encryption_set_id
+  role_definition_id = local.custom_des_role ? azurerm_role_definition.des[0].role_definition_resource_id : null
+  principal_id       = data.azuread_service_principal.aro_resource_provider.object_id
 }

--- a/permissions.tf
+++ b/permissions.tf
@@ -1,12 +1,19 @@
 #
-# objects
+# object ids
 #
-data "azurerm_subscription" "current" {}
-
 locals {
+  # network object ids
   vnet_id                   = "${local.network_resource_group_id}/providers/Microsoft.Network/virtualNetworks/${var.vnet}"
   network_security_group_id = (var.network_security_group == null || var.network_security_group == "") ? null : "${local.network_resource_group_id}/providers/Microsoft.Network/networkSecurityGroups/${var.network_security_group}"
-  disk_encryption_set_id    = (var.disk_encryption_set == null || var.disk_encryption_set == "") ? null : "${local.aro_resource_group_id}/providers/Microsoft.Compute/diskEncryptionSets/${var.disk_encryption_set}"
+  route_table_ids = length(var.route_tables) == 0 || var.route_tables == null ? [] : [
+    for route_table in var.route_tables : "${local.network_resource_group_id}/providers/Microsoft.Network/routeTables/${route_table}"
+  ]
+  nat_gateway_ids = length(var.nat_gateways) == 0 || var.nat_gateways == null ? [] : [
+    for nat_gateway in var.nat_gateways : "${local.network_resource_group_id}/providers/Microsoft.Network/natGateways/${nat_gateway}"
+  ]
+
+  # other object ids
+  disk_encryption_set_id = (var.disk_encryption_set == null || var.disk_encryption_set == "") ? null : "${local.aro_resource_group_id}/providers/Microsoft.Compute/diskEncryptionSets/${var.disk_encryption_set}"
 }
 
 #
@@ -16,18 +23,36 @@ locals {
 # permission 1: assign cluster identity with appropriate vnet permissions
 resource "azurerm_role_assignment" "cluster_vnet" {
   scope                = local.vnet_id
-  role_definition_id   = local.custom_network_role ? azurerm_role_definition.network[0].role_definition_resource_id : null
-  role_definition_name = local.custom_network_role ? null : "Network Contributor"
+  role_definition_id   = local.has_custom_network_role ? azurerm_role_definition.network[0].role_definition_resource_id : null
+  role_definition_name = local.has_custom_network_role ? null : "Network Contributor"
+  principal_id         = local.cluster_service_principal_object_id
+}
+
+resource "azurerm_role_assignment" "cluster_route_tables" {
+  count = length(local.route_table_ids)
+
+  scope                = local.route_table_ids[count.index]
+  role_definition_id   = local.has_custom_network_role ? azurerm_role_definition.network_route_tables[count.index].role_definition_resource_id : null
+  role_definition_name = local.has_custom_network_role ? null : "Network Contributor"
+  principal_id         = local.cluster_service_principal_object_id
+}
+
+resource "azurerm_role_assignment" "cluster_nat_gateways" {
+  count = length(local.nat_gateway_ids)
+
+  scope                = local.nat_gateway_ids[count.index]
+  role_definition_id   = local.has_custom_network_role ? azurerm_role_definition.network_nat_gateways[0].role_definition_resource_id : null
+  role_definition_name = local.has_custom_network_role ? null : "Network Contributor"
   principal_id         = local.cluster_service_principal_object_id
 }
 
 # permission 2: assign cluster identity with appropriate network security group permissions
 resource "azurerm_role_assignment" "cluster_network_security_group" {
-  count = (var.network_security_group == null || var.network_security_group == "") ? 0 : 1
+  count = (var.network_security_group != null && var.network_security_group != "") ? 1 : 0
 
   scope                            = local.network_security_group_id
-  role_definition_id               = local.custom_network_role ? azurerm_role_definition.network[0].role_definition_resource_id : null
-  role_definition_name             = local.custom_network_role ? null : "Network Contributor"
+  role_definition_id               = local.has_custom_network_role ? azurerm_role_definition.network_network_security_group[0].role_definition_resource_id : null
+  role_definition_name             = local.has_custom_network_role ? null : "Network Contributor"
   principal_id                     = local.cluster_service_principal_object_id
   skip_service_principal_aad_check = var.cluster_service_principal.create
 }
@@ -42,10 +67,10 @@ resource "azurerm_role_assignment" "cluster_aro_resource_group" {
 
 # permission 4: assign cluster identity with appropriate disk encryption set permissions
 resource "azurerm_role_assignment" "cluster_disk_encryption_set" {
-  count = local.custom_des_role ? 1 : 0
+  count = local.has_custom_des_role ? 1 : 0
 
   scope                            = local.disk_encryption_set_id
-  role_definition_id               = local.custom_des_role ? azurerm_role_definition.des[0].role_definition_resource_id : null
+  role_definition_id               = local.has_custom_des_role ? azurerm_role_definition.des[0].role_definition_resource_id : null
   principal_id                     = local.cluster_service_principal_object_id
   skip_service_principal_aad_check = var.cluster_service_principal.create
 }
@@ -57,8 +82,8 @@ resource "azurerm_role_assignment" "cluster_disk_encryption_set" {
 # permission 5: assign installer identity with appropriate aro resource group permissions
 resource "azurerm_role_assignment" "installer_aro_resource_group" {
   scope                            = local.aro_resource_group_id
-  role_definition_id               = local.custom_aro_role ? azurerm_role_definition.aro[0].role_definition_resource_id : null
-  role_definition_name             = local.custom_aro_role ? null : "Contributor"
+  role_definition_id               = local.has_custom_aro_role ? azurerm_role_definition.aro[0].role_definition_resource_id : null
+  role_definition_name             = local.has_custom_aro_role ? null : "Contributor"
   principal_id                     = local.installer_object_id
   skip_service_principal_aad_check = var.installer_service_principal.create
 }
@@ -77,7 +102,7 @@ resource "azurerm_role_assignment" "installer_network_resource_group" {
 resource "azurerm_role_assignment" "installer_subscription" {
   count = var.installation_type == "cli" ? 1 : 0
 
-  scope                            = data.azurerm_subscription.current.id
+  scope                            = local.subscription_id
   role_definition_name             = "User Access Administrator"
   principal_id                     = local.installer_object_id
   skip_service_principal_aad_check = var.installer_service_principal.create
@@ -103,8 +128,8 @@ resource "azurerm_role_assignment" "installer_vnet" {
   count = var.installation_type == "cli" ? 1 : 0
 
   scope                = local.vnet_id
-  role_definition_id   = local.custom_network_role ? azurerm_role_definition.network[0].role_definition_resource_id : null
-  role_definition_name = local.custom_network_role ? null : "Network Contributor"
+  role_definition_id   = local.has_custom_network_role ? azurerm_role_definition.network[0].role_definition_resource_id : null
+  role_definition_name = local.has_custom_network_role ? null : "Network Contributor"
   principal_id         = local.installer_object_id
 }
 
@@ -115,8 +140,26 @@ resource "azurerm_role_assignment" "installer_vnet" {
 # permission 10: assign resource provider service principal with appropriate vnet permissions
 resource "azurerm_role_assignment" "resource_provider_vnet" {
   scope                = local.vnet_id
-  role_definition_id   = local.custom_network_role ? azurerm_role_definition.network[0].role_definition_resource_id : null
-  role_definition_name = local.custom_network_role ? null : "Network Contributor"
+  role_definition_id   = local.has_custom_network_role ? azurerm_role_definition.network[0].role_definition_resource_id : null
+  role_definition_name = local.has_custom_network_role ? null : "Network Contributor"
+  principal_id         = data.azuread_service_principal.aro_resource_provider.object_id
+}
+
+resource "azurerm_role_assignment" "resource_provider_route_tables" {
+  count = length(local.route_table_ids)
+
+  scope                = local.route_table_ids[count.index]
+  role_definition_id   = local.has_custom_network_role ? azurerm_role_definition.network_route_tables[count.index].role_definition_resource_id : null
+  role_definition_name = local.has_custom_network_role ? null : "Network Contributor"
+  principal_id         = data.azuread_service_principal.aro_resource_provider.object_id
+}
+
+resource "azurerm_role_assignment" "resource_provider_nat_gateways" {
+  count = length(local.nat_gateway_ids)
+
+  scope                = local.nat_gateway_ids[count.index]
+  role_definition_id   = local.has_custom_network_role ? azurerm_role_definition.network_nat_gateways[0].role_definition_resource_id : null
+  role_definition_name = local.has_custom_network_role ? null : "Network Contributor"
   principal_id         = data.azuread_service_principal.aro_resource_provider.object_id
 }
 
@@ -125,16 +168,16 @@ resource "azurerm_role_assignment" "resource_provider_network_security_group" {
   count = (var.network_security_group == null || var.network_security_group == "") ? 0 : 1
 
   scope                = local.network_security_group_id
-  role_definition_id   = local.custom_network_role ? azurerm_role_definition.network[0].role_definition_resource_id : null
-  role_definition_name = local.custom_network_role ? null : "Network Contributor"
+  role_definition_id   = local.has_custom_network_role ? azurerm_role_definition.network_network_security_group[0].role_definition_resource_id : null
+  role_definition_name = local.has_custom_network_role ? null : "Network Contributor"
   principal_id         = data.azuread_service_principal.aro_resource_provider.object_id
 }
 
 # permission 12: assign resource provider service principal with appropriate disk encryption set permissions
 resource "azurerm_role_assignment" "resource_provider_disk_encryption_set" {
-  count = local.custom_des_role ? 1 : 0
+  count = local.has_custom_des_role ? 1 : 0
 
   scope              = local.disk_encryption_set_id
-  role_definition_id = local.custom_des_role ? azurerm_role_definition.des[0].role_definition_resource_id : null
+  role_definition_id = local.has_custom_des_role ? azurerm_role_definition.des[0].role_definition_resource_id : null
   principal_id       = data.azuread_service_principal.aro_resource_provider.object_id
 }

--- a/provider.tf
+++ b/provider.tf
@@ -12,12 +12,22 @@ terraform {
   }
 }
 
+#
+# provider configuration
+#
 data "azuread_client_config" "current" {}
+
+data "azurerm_client_config" "current" {}
+
+locals {
+  subscription_id = var.subscription_id == null || var.subscription_id == "" ? data.azurerm_client_config.current.subscription_id : var.subscription_id
+  tenant_id       = var.tenant_id == null || var.tenant_id == "" ? data.azurerm_client_config.current.tenant_id : var.tenant_id
+}
 
 provider "azurerm" {
   environment     = var.environment
-  subscription_id = var.subscription_id
-  tenant_id       = var.tenant_id
+  subscription_id = local.subscription_id
+  tenant_id       = local.tenant_id
 
   features {
     resource_group {

--- a/provider.tf
+++ b/provider.tf
@@ -21,13 +21,12 @@ data "azurerm_client_config" "current" {}
 
 locals {
   subscription_id = var.subscription_id == null || var.subscription_id == "" ? data.azurerm_client_config.current.subscription_id : var.subscription_id
-  tenant_id       = var.tenant_id == null || var.tenant_id == "" ? data.azurerm_client_config.current.tenant_id : var.tenant_id
 }
 
 provider "azurerm" {
   environment     = var.environment
-  subscription_id = local.subscription_id
-  tenant_id       = local.tenant_id
+  subscription_id = var.subscription_id # we cannot use a local here due to import cycle; a null value uses the client config
+  tenant_id       = var.tenant_id       # we cannot use a local here due to import cycle; a null value uses the client config
 
   features {
     resource_group {

--- a/resource_groups.tf
+++ b/resource_groups.tf
@@ -1,26 +1,14 @@
-locals {
-  network_resource_group = (var.vnet_resource_group == null || var.vnet_resource_group == "") ? var.aro_resource_group.name : var.vnet_resource_group
-}
-
-data "azurerm_resource_group" "aro" {
-  count = var.aro_resource_group.create ? 0 : 1
-
-  name = var.aro_resource_group.name
-}
-
-data "azurerm_resource_group" "network" {
-  name = local.network_resource_group
-}
-
 # NOTE: create the resource group if it is requested.  this assumes vnet is in the same location as this resource group.
 resource "azurerm_resource_group" "aro" {
   count = var.aro_resource_group.create ? 1 : 0
 
   name     = var.aro_resource_group.name
-  location = data.azurerm_virtual_network.vnet.location
+  location = var.location
 }
 
-# NOTE: we do this to ensure order of operations an validate the resource group exists if we are not creating
 locals {
-  aro_resource_group = var.aro_resource_group.create ? azurerm_resource_group.aro[0] : data.azurerm_resource_group.aro[0]
+  aro_resource_group_name     = var.aro_resource_group.create ? azurerm_resource_group.aro[0].name : var.aro_resource_group.name
+  aro_resource_group_id       = var.aro_resource_group.create ? azurerm_resource_group.aro[0].id : "/subscriptions/${var.subscription_id}/resourceGroups/${var.aro_resource_group.name}"
+  network_resource_group_name = (var.vnet_resource_group == null || var.vnet_resource_group == "") ? var.aro_resource_group.name : var.vnet_resource_group
+  network_resource_group_id   = "/subscriptions/${var.subscription_id}/resourceGroups/${local.network_resource_group_name}"
 }

--- a/resource_groups.tf
+++ b/resource_groups.tf
@@ -8,7 +8,7 @@ resource "azurerm_resource_group" "aro" {
 
 locals {
   aro_resource_group_name     = var.aro_resource_group.create ? azurerm_resource_group.aro[0].name : var.aro_resource_group.name
-  aro_resource_group_id       = var.aro_resource_group.create ? azurerm_resource_group.aro[0].id : "/subscriptions/${var.subscription_id}/resourceGroups/${var.aro_resource_group.name}"
+  aro_resource_group_id       = var.aro_resource_group.create ? azurerm_resource_group.aro[0].id : "/subscriptions/${local.subscription_id}/resourceGroups/${var.aro_resource_group.name}"
   network_resource_group_name = (var.vnet_resource_group == null || var.vnet_resource_group == "") ? var.aro_resource_group.name : var.vnet_resource_group
-  network_resource_group_id   = "/subscriptions/${var.subscription_id}/resourceGroups/${local.network_resource_group_name}"
+  network_resource_group_id   = "/subscriptions/${local.subscription_id}/resourceGroups/${local.network_resource_group_name}"
 }

--- a/roles.tf
+++ b/roles.tf
@@ -76,27 +76,3 @@ resource "azurerm_role_definition" "aro" {
 
   assignable_scopes = [local.aro_resource_group.id]
 }
-
-#
-# directory reader role
-#   NOTE: we do this only because using the azapi provider it is not obvious how to accomplish this and TF does not have a direct role
-#         for azure ad roles
-#   TODO: fix this
-#
-
-## The role ID for this role definition will always be 88d8e3e3-8f55-4a1e-953a-9b9898b8876b
-## https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json#directory-readers
-## This can be added as a variable and referenced.
-# locals {
-#   directory_reader_role_command = <<-EOT
-# ID=$(az rest --method GET --url https://graph.microsoft.com/v1.0/roleManagement/directory/roleDefinitions | jq -r '.value[] | select(.displayName == "Directory Readers") | .templateId') && echo "{\"id\":\"$ID\"}"
-# EOT
-# }
-
-# data "external" "directory_reader_role" {
-#   program = [
-#     "sh",
-#     "-c",
-#     local.directory_reader_role_command
-#   ]
-# }

--- a/roles.tf
+++ b/roles.tf
@@ -2,58 +2,102 @@
 # minimal network role
 #
 locals {
-  custom_network_role = (var.minimal_network_role != null && var.minimal_network_role != "")
+  has_custom_network_role = (var.minimal_network_role != null && var.minimal_network_role != "")
 
-  # base permissions needed by all
-  network_permissions = [
+  # permissions needed on vnets
+  vnet_permissions = [
     "Microsoft.Network/virtualNetworks/join/action",
     "Microsoft.Network/virtualNetworks/read",
     "Microsoft.Network/virtualNetworks/write",
     "Microsoft.Network/virtualNetworks/subnets/join/action",
     "Microsoft.Network/virtualNetworks/subnets/read",
-    "Microsoft.Network/virtualNetworks/subnets/write",
-    "Microsoft.Network/networkSecurityGroups/join/action"
+    "Microsoft.Network/virtualNetworks/subnets/write"
   ]
 
   # permissions needed by vnets with route tables
-  route_table_permissions = var.vnet_has_route_tables ? [
+  route_table_permissions = [
     "Microsoft.Network/routeTables/join/action",
     "Microsoft.Network/routeTables/read",
     "Microsoft.Network/routeTables/write"
-  ] : []
+  ]
 
   # permissions needed by vnets with nat gateways
-  nat_gateway_permissions = var.vnet_has_nat_gateways ? [
+  nat_gateway_permissions = [
     "Microsoft.Network/natGateways/join/action",
     "Microsoft.Network/natGateways/read",
     "Microsoft.Network/natGateways/write"
-  ] : []
+  ]
 
-  # scopes
-  network_role_base_scope        = local.vnet_id
-  network_role_assignable_scopes = (var.network_security_group == null || var.network_security_group == "") ? [local.network_role_base_scope] : [local.network_role_base_scope, local.network_security_group_id]
+  # permissions needed by vnets which use a custom network security group
+  network_security_group_permissions = [
+    "Microsoft.Network/networkSecurityGroups/join/action"
+  ]
 }
 
+# vnet
 resource "azurerm_role_definition" "network" {
-  count = local.custom_network_role ? 1 : 0
+  count = local.has_custom_network_role ? 1 : 0
 
-  name        = var.minimal_network_role
-  description = "Custom role for ARO network for cluster: ${var.cluster_name}"
-  scope       = local.network_role_base_scope
+  name              = var.minimal_network_role
+  description       = "Custom role for ARO network for cluster: ${var.cluster_name}"
+  scope             = local.vnet_id
+  assignable_scopes = [local.vnet_id]
 
   permissions {
-    actions = toset(flatten(concat(local.network_permissions, local.route_table_permissions, local.nat_gateway_permissions)))
+    actions = local.vnet_permissions
   }
+}
 
-  assignable_scopes = local.network_role_assignable_scopes
+# route tables
+resource "azurerm_role_definition" "network_route_tables" {
+  count = local.has_custom_network_role ? length(local.route_table_ids) : 0
+
+  name              = "${var.minimal_network_role}-rt${count.index}"
+  description       = "Custom role for ARO network route tables for cluster: ${var.cluster_name}"
+  scope             = local.route_table_ids[count.index]
+  assignable_scopes = [local.route_table_ids[count.index]]
+
+  permissions {
+    actions = local.route_table_permissions
+  }
+}
+
+# nat gateways
+resource "azurerm_role_definition" "network_nat_gateways" {
+  count = local.has_custom_network_role ? length(local.nat_gateway_ids) : 0
+
+  name              = "${var.minimal_network_role}-natgw${count.index}"
+  description       = "Custom role for ARO network NAT gateways for cluster: ${var.cluster_name}"
+  scope             = local.nat_gateway_ids[count.index]
+  assignable_scopes = [local.nat_gateway_ids[count.index]]
+
+  permissions {
+    actions = local.nat_gateway_permissions
+  }
+}
+
+# network security group
+resource "azurerm_role_definition" "network_network_security_group" {
+  count = local.has_custom_network_role && (var.network_security_group != null && var.network_security_group != "") ? 1 : 0
+
+  name              = "${var.minimal_network_role}-nsg"
+  description       = "Custom role for ARO network NSG for cluster: ${var.cluster_name}"
+  scope             = local.network_security_group_id
+  assignable_scopes = [local.network_security_group_id]
+
+  permissions {
+    actions = local.network_security_group_permissions
+  }
 }
 
 #
 # minimal aro role
 #
 locals {
-  custom_aro_role = (var.minimal_aro_role != null && var.minimal_aro_role != "")
+  has_custom_aro_role = (var.minimal_aro_role != null && var.minimal_aro_role != "")
+  has_custom_des_role = (var.disk_encryption_set != null && var.disk_encryption_set != "")
 
+  # base permissions needed by all
   aro_permissions = [
     "Microsoft.RedHatOpenShift/openShiftClusters/read",
     "Microsoft.RedHatOpenShift/openShiftClusters/write",
@@ -61,43 +105,37 @@ locals {
     "Microsoft.RedHatOpenShift/openShiftClusters/listCredentials/action",
     "Microsoft.RedHatOpenShift/openShiftClusters/listAdminCredentials/action"
   ]
-}
 
-resource "azurerm_role_definition" "aro" {
-  count = local.custom_aro_role ? 1 : 0
-
-  name        = var.minimal_aro_role
-  description = "Custom role for ARO for cluster: ${var.cluster_name}"
-  scope       = local.aro_resource_group_id
-
-  permissions {
-    actions = local.aro_permissions
-  }
-
-  assignable_scopes = [local.aro_resource_group_id]
-}
-
-#
-# minimal disk encryption set role
-#
-locals {
-  custom_des_role = (var.disk_encryption_set != null && var.disk_encryption_set != "")
-
+  # permissions needed when disk encryption set is selected
   des_permissions = [
     "Microsoft.Compute/diskEncryptionSets/read"
   ]
 }
 
-resource "azurerm_role_definition" "des" {
-  count = local.custom_des_role ? 1 : 0
+# aro
+resource "azurerm_role_definition" "aro" {
+  count = local.has_custom_aro_role ? 1 : 0
 
-  name        = "${var.cluster_name}-des"
-  description = "Custom role for disk encryption set for cluster: ${var.cluster_name}"
-  scope       = local.disk_encryption_set_id
+  name              = var.minimal_aro_role
+  description       = "Custom role for ARO for cluster: ${var.cluster_name}"
+  scope             = local.aro_resource_group_id
+  assignable_scopes = [local.aro_resource_group_id]
+
+  permissions {
+    actions = local.aro_permissions
+  }
+}
+
+# disk encryption set
+resource "azurerm_role_definition" "des" {
+  count = local.has_custom_des_role ? 1 : 0
+
+  name              = "${var.cluster_name}-des"
+  description       = "Custom role for disk encryption set for cluster: ${var.cluster_name}"
+  scope             = local.disk_encryption_set_id
+  assignable_scopes = [local.disk_encryption_set_id]
 
   permissions {
     actions = local.des_permissions
   }
-
-  assignable_scopes = [local.disk_encryption_set_id]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -90,6 +90,12 @@ variable "network_security_group" {
   description = "Network security group used in a BYO-NSG scenario."
 }
 
+variable "disk_encryption_set" {
+  type        = string
+  default     = null
+  description = "Disk encryption set to use.  If specified, a role is created for allowing read access to the specified disk encryption set.  Must exist in 'aro_resource_group.name'."
+}
+
 #
 # roles
 #
@@ -102,7 +108,7 @@ variable "minimal_network_role" {
 variable "minimal_aro_role" {
   type        = string
   default     = null
-  description = "Role to manaae to substitute for full 'Contributor' on the ARO resource group.  If specified, this is created."
+  description = "Role to manage to substitute for full 'Contributor' on the ARO resource group.  If specified, this is created."
 }
 
 #
@@ -131,8 +137,17 @@ variable "tenant_id" {
   description = "Explicitly use a specific Azure tenant id (defaults to the current system configuration)."
 }
 
-variable "directory_reader_role_id" {
-  type = string
-  default = "88d8e3e3-8f55-4a1e-953a-9b9898b8876b"
-  description = "Directory Readers role ID"  
+variable "location" {
+  type        = string
+  default     = "eastus"
+  description = "Azure region where region-specific objects exist or are to be created."
+}
+
+#
+# output
+#
+variable "output_as_file" {
+  type        = bool
+  default     = true
+  description = "Output created service principal client identifier and client secret into a source file."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -71,17 +71,17 @@ variable "vnet_resource_group" {
 }
 
 # TODO: pull from data sources
-variable "vnet_has_route_tables" {
-  type        = bool
-  default     = false
-  description = "Specify if the VNET has route tables attached."
+variable "route_tables" {
+  type        = list(string)
+  default     = []
+  description = "Names of route tables for user-defined routing.  Route tables are assumed to exist in 'vnet_resource_group'."
 }
 
 # TODO: pull from data sources
-variable "vnet_has_nat_gateways" {
-  type        = bool
-  default     = false
-  description = "Specify if the VNET has NAT gateways attached."
+variable "nat_gateways" {
+  type        = list(string)
+  default     = []
+  description = "Names of NAT gateways for user-defined routing.  NAT gateways are assumed to exist in 'vnet_resource_group'."
 }
 
 variable "network_security_group" {
@@ -102,13 +102,13 @@ variable "disk_encryption_set" {
 variable "minimal_network_role" {
   type        = string
   default     = null
-  description = "Role to manage to substitute for full 'Network Contributor' on network objects.  If specified, this is created."
+  description = "Role to manage to substitute for full 'Network Contributor' on network objects.  If specified, this is created, otherwise 'Network Contributor' is used.  For objects such as NSGs, route tables, and NAT gateways, this is used as a prefix for the role."
 }
 
 variable "minimal_aro_role" {
   type        = string
   default     = null
-  description = "Role to manage to substitute for full 'Contributor' on the ARO resource group.  If specified, this is created."
+  description = "Role to manage to substitute for full 'Contributor' on the ARO resource group.  If specified, this is created, otherwise 'Contributor' is used.  For objects such as disk encryption sets, this is used as a prefix for the role."
 }
 
 #


### PR DESCRIPTION
This PR addresses the following:

- Fixes #5 , adds the appropriate permission on the disk encryption set
- Tested integration and consumption externally and provides several fixes to make the module more consumable (tested with terraform-aro repo)
- Assigns appropriate permissions to appropriate objects.  Previously one big role was created and assigned at the VNET which was incorrect.  This is now scoped to NSG, NAT GW, Route Table, etc.
- Removes data lookups - data lookups make the module less consumable as they cause potential lookup for objects that do not exist yet (e.g. created in a calling module).  These were simply used to the pull the ID which is predictable in Azure.  Switched to string interpolation to address this.